### PR TITLE
Removed BOM from compressed Payload and set chunks to be 1-based index

### DIFF
--- a/SmartHealthCard.QRCode/Chunker/SmartHealthCardJwsChunker.cs
+++ b/SmartHealthCard.QRCode/Chunker/SmartHealthCardJwsChunker.cs
@@ -57,7 +57,7 @@ namespace SmartHealthCard.QRCode.Chunker
 
           //Syntax: shc:/[This Chunk index]/[Total Chunks]/[This chunk's data]
           //shc:/2/3/56762909524320603460292437404460 ..etc
-          ChunkList.Add(new Chunk($"{Prefix}/{i}/{ChunkSizeArray.Length}/", NumericChunkData));
+          ChunkList.Add(new Chunk($"{Prefix}/{i+1}/{ChunkSizeArray.Length}/", NumericChunkData));
           StartPosition += ChunkSizeArray[i];
         }
         return ChunkList.ToArray();

--- a/SmartHealthCard.Token/Compression/DeflateCompression.cs
+++ b/SmartHealthCard.Token/Compression/DeflateCompression.cs
@@ -9,11 +9,15 @@ namespace SmartHealthCard.Token.Compression
   {
     public static async Task<byte[]> CompressAsync(string input)
     {
+      // Remove BOM and ZERO WIDTH SPACE
+      input = input.Trim(new char[] { '\uFEFF', '\u200B' });
+
       using (MemoryStream MemoryStream = new MemoryStream())
       {
         using (DeflateStream DeflateStream = new DeflateStream(MemoryStream, CompressionMode.Compress))
         {
-          using (StreamWriter StreamWriter = new StreamWriter(DeflateStream, Encoding.UTF8))
+          // set encoderShouldEmitUTF8Identifier to false to not include the BOM
+          using (StreamWriter StreamWriter = new StreamWriter(DeflateStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
           {
             await StreamWriter.WriteAsync(input);
           }


### PR DESCRIPTION
Hi Angus,

Two small changes

1. The method CompressAsync was updated to not include the BOM or ZERO WIDTH SPACE characters and that was preventing mobile apps from scanning.  This required both stripping the characters and changing the encoding used in the StreamWriter.
2. Updated the chunk index to be 1-based in case that turns out to be strict to the specification as well.  [(e.g., 1 for the first chunk, 2 for the second chunk, and so on)](https://spec.smarthealth.cards/#encoding-chunks-as-qr-codes)


